### PR TITLE
[gecko-camera] Recommend gecko-camera-droid-plugin when installing gecko-camera. Fixes JB#56216 OMP#JOLLA-511

### DIFF
--- a/rpm/gecko-camera-droid-plugin.spec
+++ b/rpm/gecko-camera-droid-plugin.spec
@@ -9,7 +9,7 @@ BuildRequires:  meson
 BuildRequires:  pkgconfig(geckocamera)
 BuildRequires:  pkgconfig(droidmedia)
 Requires:       gecko-camera
-Suggests:       droidmedia
+Requires:       droidmedia
 
 %description
 A library to simplify video capture, droidmedia-based plugin.

--- a/rpm/gecko-camera.spec
+++ b/rpm/gecko-camera.spec
@@ -6,6 +6,7 @@ License:        LGPLv2+
 URL:            https://github.com/sailfishos/gecko-camera
 Source0:        %{name}-%{version}.tar.gz
 BuildRequires:  meson
+Recommends:     gecko-camera-droid-plugin
 
 %description
 %{summary}.


### PR DESCRIPTION
xulrunner requires gecko-camera
gecko-camera recommends gecko-camera-droid-plugin

In case gecko-camera-droid-plugin is not available in the repositories
and/or its dependency chain is not satisfied then gecko-camera
is installed without recommended gecko-camera-droid-plugin.

Upside of this approach is that we do not need to touch patterns.