### PR TITLE
[gecko-camera] Use media buffers for decoded video. JB#56755

### DIFF
--- a/geckocamera-codec.h
+++ b/geckocamera-codec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Mobile Platform LLC.
+ * Copyright (C) 2021-2022 Open Mobile Platform LLC.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -84,7 +84,8 @@ class VideoDecoderListener
 {
 public:
     virtual ~VideoDecoderListener() = default;
-    virtual void onDecodedFrame(gecko::camera::YCbCrFrame frame) = 0;
+    virtual void onDecodedYCbCrFrame(const gecko::camera::YCbCrFrame *frame) = 0;
+    virtual void onDecodedGraphicBuffer(std::shared_ptr<gecko::camera::GraphicBuffer> buffer) = 0;
     virtual void onDecoderError(std::string errorDescription) = 0;
     virtual void onDecoderEOS() = 0;
 };

--- a/geckocamera.h
+++ b/geckocamera.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Mobile Platform LLC.
+ * Copyright (C) 2021-2022 Open Mobile Platform LLC.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -47,6 +47,10 @@ struct CameraInfo {
     unsigned int mountAngle;
 };
 
+enum ImageFormat {
+    YCbCr,
+};
+
 struct YCbCrFrame {
     const uint8_t *y;
     const uint8_t *cb;
@@ -59,11 +63,36 @@ struct YCbCrFrame {
     uint64_t timestampUs;
 };
 
+struct RawImageFrame {
+    const uint8_t *data;
+    size_t size;
+    ImageFormat imageFormat;
+    uint16_t width;
+    uint16_t height;
+    uint64_t timestampUs;
+};
+
+class GraphicBuffer {
+public:
+    virtual ~GraphicBuffer() = default;
+
+    uint16_t width;
+    uint16_t height;
+    uint64_t timestampUs;
+    ImageFormat imageFormat = ImageFormat::YCbCr;
+
+    // A hardware-specific handle for the underlying media buffer.
+    const void *handle;
+
+    virtual std::shared_ptr<const YCbCrFrame> mapYCbCr() = 0;
+    virtual std::shared_ptr<const RawImageFrame> map() = 0;
+};
+
 class CameraListener
 {
 public:
     virtual ~CameraListener() = default;
-    virtual void onCameraFrame(std::shared_ptr<const YCbCrFrame> frame) = 0;
+    virtual void onCameraFrame(std::shared_ptr<GraphicBuffer> buffer) = 0;
     virtual void onCameraError(std::string errorDescription) = 0;
 };
 

--- a/plugins/droid/droid-common.cpp
+++ b/plugins/droid/droid-common.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2022 Open Mobile Platform LLC.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "geckocamera-utils.h"
+#include "droid-common.h"
+
+using namespace std;
+using namespace gecko::camera;
+
+DroidRawImageFrame::~DroidRawImageFrame()
+{
+    LOGV("buffer: " << (void *)m_buffer);
+
+    if (m_buffer) {
+        droid_media_buffer_unlock(m_buffer);
+    }
+}
+
+bool DroidRawImageFrame::map(DroidGraphicBuffer *buffer, DroidMediaBuffer *droidBuffer)
+{
+    const void *imageData = droid_media_buffer_lock(droidBuffer, DROID_MEDIA_BUFFER_LOCK_READ);
+    if (imageData) {
+        data = static_cast<const uint8_t *>(imageData);
+        width = buffer->width;
+        height = buffer->height;
+        imageFormat = buffer->imageFormat;
+        timestampUs = buffer->timestampUs;
+        m_buffer = droidBuffer;
+
+        LOGV("created " << this
+             << " data=" << (const void *)data
+             << " timestampUs=" << timestampUs);
+        return true;
+    }
+    return false;
+}
+
+DroidYCbCrFrame::~DroidYCbCrFrame()
+{
+    LOGV("buffer: " << (void *)m_buffer);
+
+    if (m_buffer) {
+        droid_media_buffer_unlock(m_buffer);
+    }
+}
+
+bool DroidYCbCrFrame::map(DroidGraphicBuffer *buffer, DroidMediaBuffer *droidBuffer)
+{
+    DroidMediaBufferYCbCr ycbcr;
+
+    if (droid_media_buffer_lock_ycbcr(droidBuffer,
+                DROID_MEDIA_BUFFER_LOCK_READ,
+                &ycbcr)) {
+        y = static_cast<const uint8_t*>(ycbcr.y);
+        cb = static_cast<const uint8_t*>(ycbcr.cb);
+        cr = static_cast<const uint8_t*>(ycbcr.cr);
+        yStride = ycbcr.ystride;
+        cStride = ycbcr.cstride;
+        chromaStep = ycbcr.chroma_step;
+        width = buffer->width;
+        height = buffer->height;
+        timestampUs = buffer->timestampUs;
+        m_buffer = droidBuffer;
+
+        LOGV("created " << this
+             << " y=" << (const void *)y
+             << " yStride=" << yStride
+             << " cStride=" << cStride
+             << " chromaStep=" << chromaStep
+             << " timestampUs=" << timestampUs);
+
+        return true;
+    }
+    return false;
+}
+
+DroidGraphicBuffer::DroidGraphicBuffer(
+    DroidObject *parent,
+    DroidMediaBuffer *buffer)
+    : DroidObject(parent)
+    , m_droidBuffer(buffer)
+{
+    width = droid_media_buffer_get_width(buffer);
+    height = droid_media_buffer_get_height(buffer);
+    handle = buffer;
+    timestampUs = droid_media_buffer_get_timestamp(buffer) / 1000;
+}
+
+DroidGraphicBuffer::~DroidGraphicBuffer()
+{
+    droid_media_buffer_release(m_droidBuffer, NULL, 0);
+}
+
+shared_ptr<const YCbCrFrame> DroidGraphicBuffer::mapYCbCr()
+{
+    shared_ptr<DroidYCbCrFrame> ptr = make_shared<DroidYCbCrFrame>(this);
+    bool success = false;
+
+    if (m_droidBuffer && imageFormat == ImageFormat::YCbCr) {
+        success = ptr->map(this, m_droidBuffer);
+    }
+    return success ? static_pointer_cast<YCbCrFrame>(ptr) : nullptr;
+}
+
+shared_ptr<const RawImageFrame> DroidGraphicBuffer::map()
+{
+    shared_ptr<DroidRawImageFrame> ptr = make_shared<DroidRawImageFrame>(this);
+    bool success = false;
+
+    if (m_droidBuffer) {
+        success = ptr->map(this, m_droidBuffer);
+    }
+    return success ? static_pointer_cast<RawImageFrame>(ptr) : nullptr;
+}
+
+DroidGraphicBufferPool::Item::Item(DroidObject *parent, DroidMediaBuffer *buffer)
+    : DroidObject(parent)
+    , m_buffer(buffer)
+{
+}
+
+DroidGraphicBufferPool::Item::~Item()
+{
+    droid_media_buffer_destroy(m_buffer);
+}
+
+std::shared_ptr<GraphicBuffer> DroidGraphicBufferPool::Item::acquire()
+{
+    return std::make_shared<DroidGraphicBuffer>(this, m_buffer);
+}
+
+bool DroidGraphicBufferPool::bind(DroidObject *parent, DroidMediaBuffer *buffer)
+{
+    // Create the new pool item and store its index+1 in buffer's user data
+    m_items.push_back(make_shared<Item>(parent, buffer));
+    droid_media_buffer_set_user_data(buffer, (void*)m_items.size());
+    return true;
+}
+
+shared_ptr<GraphicBuffer> DroidGraphicBufferPool::acquire(DroidMediaBuffer *buffer)
+{
+    size_t index = (size_t)droid_media_buffer_get_user_data(buffer);
+    if (index && index <= m_items.size()) {
+        return m_items[index - 1]->acquire();
+    }
+    return nullptr;
+}
+
+void DroidGraphicBufferPool::clear()
+{
+    m_items.clear();
+}
+
+/* vim: set ts=4 et sw=4 tw=80: */

--- a/plugins/droid/droid-common.h
+++ b/plugins/droid/droid-common.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2022 Open Mobile Platform LLC.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __GECKOCAMERA_DROID_COMMON__
+#define __GECKOCAMERA_DROID_COMMON__
+
+#include <memory>
+#include <vector>
+#include <droidmedia.h>
+
+#include "geckocamera.h"
+
+namespace gecko {
+namespace camera {
+
+class DroidGraphicBuffer;
+
+class DroidObject : public std::enable_shared_from_this<DroidObject>
+{
+public:
+    DroidObject(DroidObject *parent = nullptr)
+        : m_parent(parent ? parent->shared_from_this() : nullptr)
+    {
+    }
+
+private:
+    std::shared_ptr<DroidObject> m_parent;
+};
+
+
+class DroidRawImageFrame : public RawImageFrame, public DroidObject
+{
+public:
+    explicit DroidRawImageFrame(DroidObject *parent)
+        : DroidObject(parent)
+    {
+    }
+
+    ~DroidRawImageFrame();
+
+    bool map(DroidGraphicBuffer *buffer, DroidMediaBuffer *droidBuffer);
+
+private:
+    DroidMediaBuffer *m_buffer = nullptr;
+};
+
+
+class DroidYCbCrFrame : public YCbCrFrame, public DroidObject
+{
+public:
+    explicit DroidYCbCrFrame(DroidObject *parent)
+        : DroidObject(parent)
+    {
+    }
+
+    ~DroidYCbCrFrame();
+
+    bool map(DroidGraphicBuffer *buffer, DroidMediaBuffer *droidBuffer);
+
+private:
+    DroidMediaBuffer *m_buffer = nullptr;
+};
+
+
+class DroidGraphicBuffer : public GraphicBuffer, public DroidObject
+{
+public:
+    static std::shared_ptr<DroidGraphicBuffer> create(
+        DroidObject *parent,
+        DroidMediaBuffer *buffer)
+    {
+        return std::make_shared<DroidGraphicBuffer>(parent, buffer);
+    }
+
+    explicit DroidGraphicBuffer(DroidObject *parent, DroidMediaBuffer *buffer);
+
+    ~DroidGraphicBuffer();
+
+    virtual std::shared_ptr<const YCbCrFrame> mapYCbCr() override;
+    virtual std::shared_ptr<const RawImageFrame> map() override;
+
+private:
+    DroidMediaBuffer *m_droidBuffer;
+};
+
+
+class DroidGraphicBufferPool
+{
+public:
+    std::shared_ptr<GraphicBuffer> acquire(DroidMediaBuffer *buffer);
+    bool bind(DroidObject *parent, DroidMediaBuffer *buffer);
+    void clear();
+
+private:
+    class Item : public DroidObject
+    {
+    public:
+        Item(DroidObject *parent, DroidMediaBuffer *buffer);
+        ~Item();
+        std::shared_ptr<GraphicBuffer> acquire();
+
+    private:
+        DroidMediaBuffer *m_buffer;
+    };
+
+    std::vector<std::shared_ptr<Item>> m_items;
+};
+
+} // namespace camera
+} // namespace gecko
+
+#endif // __GECKOCAMERA_DROID_COMMON___
+/* vim: set ts=4 et sw=4 tw=80: */

--- a/plugins/droid/meson.build
+++ b/plugins/droid/meson.build
@@ -1,6 +1,7 @@
 droid_plugin_source = [
   'droid-camera.cpp',
   'droid-codec.cpp',
+  'droid-common.cpp',
 ]
 
 droidmedia_dep=dependency('droidmedia', required: false)


### PR DESCRIPTION
This commit introduces the GraphicBuffer abstraction for the raw video
data. The GraphicBuffer can be mmap'ed to YCbCrFrame or RawImageFrame
depending on the image format.

After applying this commit, the droid decoder will use the YUVFlexible
image format and media buffers to deliver the decoded data. This behavior
is enabled by default.

On some devices droid_media_buffer_lock() is slow, so the use of media
buffers should be disabled with GECKO_CAMERA_DROID_NO_MEDIA_BUFFER
environment variable.