### PR TITLE
[gecko-camera] Set up the video encoder to produce CBR stream. JB#57733

### DIFF
--- a/plugins/droid/droid-codec.cpp
+++ b/plugins/droid/droid-codec.cpp
@@ -334,6 +334,7 @@ bool DroidVideoEncoder::init(VideoEncoderMetadata metadata)
     m_metadata.stride = metadata.stride;
     m_metadata.slice_height = metadata.sliceHeight;
     m_metadata.meta_data = false;
+    m_metadata.bitrate_mode = DROID_MEDIA_CODEC_BITRATE_CONTROL_CBR;
 
     droid_media_colour_format_constants_init (&m_constants);
     m_metadata.color_format = -1;


### PR DESCRIPTION
Set up the video encoder to produce a constant bitrate stream because
the VBR stream that is generated by default conflicts with internal
WebRTC bandwidth limiting algorithms.